### PR TITLE
Remove shared executorService shutdown call from KafkaConsumer

### DIFF
--- a/src/main/java/us/b3k/kafka/ws/consumer/KafkaConsumer.java
+++ b/src/main/java/us/b3k/kafka/ws/consumer/KafkaConsumer.java
@@ -124,7 +124,7 @@ public class KafkaConsumer {
                     case "kafka-binary":
                         sendBinary(topic, message);
                         break;
-                    case "kafka-text":
+                    default:
                         sendText(topic, message);
                         break;
                 }


### PR DESCRIPTION
Hey, thanks for the project.
When I refresh my browser, I get a WebSocketException (appended below). When the KafkaConsumer's "stop" method is called, it shuts down the executorService. But that executorService is shared by all the KafkaConsumers. So I just removed the "executorService.shutdownNow" call.

```
org.eclipse.jetty.websocket.api.WebSocketException: Cannot call method public void us.b3k.kafka.ws.KafkaWebsocketEndpoint#onOpen(javax.websocket.Session) with args: [org.eclipse.jetty.websocket.jsr356.JsrSession]
        at org.eclipse.jetty.websocket.common.events.annotated.CallableMethod.call(CallableMethod.java:99)
        at org.eclipse.jetty.websocket.jsr356.annotations.OnOpenCallable.call(OnOpenCallable.java:54)
        at org.eclipse.jetty.websocket.jsr356.annotations.JsrEvents.callOpen(JsrEvents.java:157)
        at org.eclipse.jetty.websocket.jsr356.endpoints.JsrAnnotatedEventDriver.onConnect(JsrAnnotatedEventDriver.java:174)
        at org.eclipse.jetty.websocket.common.events.AbstractEventDriver.openSession(AbstractEventDriver.java:227)
        at org.eclipse.jetty.websocket.jsr356.endpoints.AbstractJsrEventDriver.openSession(AbstractJsrEventDriver.java:105)
        at org.eclipse.jetty.websocket.common.WebSocketSession.open(WebSocketSession.java:406)
        at org.eclipse.jetty.websocket.server.WebSocketServerConnection.onOpen(WebSocketServerConnection.java:63)
        at org.eclipse.jetty.server.HttpConnection.completed(HttpConnection.java:318)
        at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:406)
        at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:232)
        at org.eclipse.jetty.io.AbstractConnection$1.run(AbstractConnection.java:505)
        at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:607)
        at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:536)
        at java.lang.Thread.run(Thread.java:744)
Caused by: java.lang.reflect.InvocationTargetException
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:606)
        at org.eclipse.jetty.websocket.common.events.annotated.CallableMethod.call(CallableMethod.java:71)
        ... 14 more
Caused by: java.util.concurrent.RejectedExecutionException: Task java.util.concurrent.FutureTask@57447eb4 rejected from java.util.concurrent.ThreadPoolExecutor@51da882e[Terminated, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 1]
        at java.util.concurrent.ThreadPoolExecutor$AbortPolicy.rejectedExecution(ThreadPoolExecutor.java:2048)
        at java.util.concurrent.ThreadPoolExecutor.reject(ThreadPoolExecutor.java:821)
        at java.util.concurrent.ThreadPoolExecutor.execute(ThreadPoolExecutor.java:1372)
        at java.util.concurrent.AbstractExecutorService.submit(AbstractExecutorService.java:110)
        at us.b3k.kafka.ws.consumer.KafkaConsumer.start(KafkaConsumer.java:82)
        at us.b3k.kafka.ws.consumer.KafkaConsumerFactory.getConsumer(KafkaConsumerFactory.java:44)
        at us.b3k.kafka.ws.consumer.KafkaConsumerFactory.getConsumer(KafkaConsumerFactory.java:30)
        at us.b3k.kafka.ws.KafkaWebsocketEndpoint.onOpen(KafkaWebsocketEndpoint.java:84)
        ... 19 more
```
