### PR TITLE
Allow discarding messages via transforms

### DIFF
--- a/src/main/java/us/b3k/kafka/ws/consumer/KafkaConsumer.java
+++ b/src/main/java/us/b3k/kafka/ws/consumer/KafkaConsumer.java
@@ -142,7 +142,7 @@ public class KafkaConsumer {
 
         private void sendBinary(String topic, byte[] message) {
             AbstractMessage msg = transform.transform(new BinaryMessage(topic, message), session);
-            if(!msg.discard) {
+            if(!msg.isDiscard()) {
                 remoteEndpoint.sendObject(msg);
             }
         }
@@ -151,7 +151,7 @@ public class KafkaConsumer {
             String messageString = new String(message, Charset.forName("UTF-8"));
             LOG.trace("XXX Sending text message to remote endpoint: {} {}", topic, messageString);
             AbstractMessage msg = transform.transform(new TextMessage(topic, messageString), session);
-            if(!msg.discard) {
+            if(!msg.isDiscard()) {
                 remoteEndpoint.sendObject(msg);
             }
         }

--- a/src/main/java/us/b3k/kafka/ws/consumer/KafkaConsumer.java
+++ b/src/main/java/us/b3k/kafka/ws/consumer/KafkaConsumer.java
@@ -22,6 +22,7 @@ import kafka.javaapi.consumer.ConsumerConnector;
 import kafka.message.MessageAndMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import us.b3k.kafka.ws.messages.AbstractMessage;
 import us.b3k.kafka.ws.messages.BinaryMessage;
 import us.b3k.kafka.ws.messages.TextMessage;
 import us.b3k.kafka.ws.transforms.Transform;
@@ -140,13 +141,19 @@ public class KafkaConsumer {
         }
 
         private void sendBinary(String topic, byte[] message) {
-            remoteEndpoint.sendObject(transform.transform(new BinaryMessage(topic, message), session));
+            AbstractMessage msg = transform.transform(new BinaryMessage(topic, message), session);
+            if(!msg.discard) {
+                remoteEndpoint.sendObject(msg);
+            }
         }
 
         private void sendText(String topic, byte[] message) {
             String messageString = new String(message, Charset.forName("UTF-8"));
             LOG.trace("XXX Sending text message to remote endpoint: {} {}", topic, messageString);
-            remoteEndpoint.sendObject(transform.transform(new TextMessage(topic, messageString), session));
+            AbstractMessage msg = transform.transform(new TextMessage(topic, messageString), session);
+            if(!msg.discard) {
+                remoteEndpoint.sendObject(msg);
+            }
         }
 
         private void closeSession(Exception e) {

--- a/src/main/java/us/b3k/kafka/ws/messages/AbstractMessage.java
+++ b/src/main/java/us/b3k/kafka/ws/messages/AbstractMessage.java
@@ -15,4 +15,6 @@ public abstract class AbstractMessage {
     }
 
     public abstract String getKey();
+
+    public Boolean discard = false;
 }

--- a/src/main/java/us/b3k/kafka/ws/messages/AbstractMessage.java
+++ b/src/main/java/us/b3k/kafka/ws/messages/AbstractMessage.java
@@ -2,6 +2,7 @@ package us.b3k.kafka.ws.messages;
 
 public abstract class AbstractMessage {
     protected String topic;
+    protected Boolean discard = false;
 
     public abstract Boolean isKeyed();
     public abstract byte[] getMessageBytes();
@@ -14,7 +15,15 @@ public abstract class AbstractMessage {
         this.topic = topic;
     }
 
+    public Boolean isDiscard() {
+        return this.discard;
+    }
+
+    public void setDiscard(Boolean discard) {
+        this.discard = discard;
+    }
+
     public abstract String getKey();
 
-    public Boolean discard = false;
+
 }

--- a/src/main/java/us/b3k/kafka/ws/producer/KafkaProducer.java
+++ b/src/main/java/us/b3k/kafka/ws/producer/KafkaProducer.java
@@ -68,13 +68,11 @@ public class KafkaProducer {
     }
 
     public void send(final BinaryMessage message, final Session session) {
-        AbstractMessage msg = inputTransform.transform(message, session);
-        send(msg);
+        send(inputTransform.transform(message, session));
     }
 
     public void send(final TextMessage message, final Session session) {
-        AbstractMessage msg = inputTransform.transform(message, session);
-        send(msg);
+        send(inputTransform.transform(message, session));
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/us/b3k/kafka/ws/producer/KafkaProducer.java
+++ b/src/main/java/us/b3k/kafka/ws/producer/KafkaProducer.java
@@ -58,7 +58,7 @@ public class KafkaProducer {
     }
 
     private void send(final AbstractMessage message) {
-        if(!message.discard) {
+        if(!message.isDiscard()) {
             if (message.isKeyed()) {
                 send(message.getTopic(), message.getKey(), message.getMessageBytes());
             } else {

--- a/src/main/java/us/b3k/kafka/ws/producer/KafkaProducer.java
+++ b/src/main/java/us/b3k/kafka/ws/producer/KafkaProducer.java
@@ -58,19 +58,23 @@ public class KafkaProducer {
     }
 
     private void send(final AbstractMessage message) {
-        if (message.isKeyed()) {
-            send(message.getTopic(), message.getKey(), message.getMessageBytes());
-        } else {
-            send(message.getTopic(), message.getMessageBytes());
+        if(!message.discard) {
+            if (message.isKeyed()) {
+                send(message.getTopic(), message.getKey(), message.getMessageBytes());
+            } else {
+                send(message.getTopic(), message.getMessageBytes());
+            }
         }
     }
 
     public void send(final BinaryMessage message, final Session session) {
-        send(inputTransform.transform(message, session));
+        AbstractMessage msg = inputTransform.transform(message, session);
+        send(msg);
     }
 
     public void send(final TextMessage message, final Session session) {
-        send(inputTransform.transform(message, session));
+        AbstractMessage msg = inputTransform.transform(message, session);
+        send(msg);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/us/b3k/kafka/ws/transforms/DiscardTransform.java
+++ b/src/main/java/us/b3k/kafka/ws/transforms/DiscardTransform.java
@@ -9,13 +9,13 @@ import javax.websocket.Session;
 public class DiscardTransform extends Transform {
     @Override
     public AbstractMessage transform(TextMessage message, final Session session) {
-        message.discard = true;
+        message.setDiscard(true);
         return message;
     }
 
     @Override
     public AbstractMessage transform(BinaryMessage message, final Session session) {
-        message.discard = true;
+        message.setDiscard(true);
         return message;
     }
 }

--- a/src/main/java/us/b3k/kafka/ws/transforms/DiscardTransform.java
+++ b/src/main/java/us/b3k/kafka/ws/transforms/DiscardTransform.java
@@ -1,0 +1,21 @@
+package us.b3k.kafka.ws.transforms;
+
+import us.b3k.kafka.ws.messages.AbstractMessage;
+import us.b3k.kafka.ws.messages.BinaryMessage;
+import us.b3k.kafka.ws.messages.TextMessage;
+
+import javax.websocket.Session;
+
+public class DiscardTransform extends Transform {
+    @Override
+    public AbstractMessage transform(TextMessage message, final Session session) {
+        message.discard = true;
+        return message;
+    }
+
+    @Override
+    public AbstractMessage transform(BinaryMessage message, final Session session) {
+        message.discard = true;
+        return message;
+    }
+}


### PR DESCRIPTION
I need a way to prevent websocket messages from ever making it to Kafka. I'm using this for a scenario where websocket clients are consumer-only.