### PR TITLE
fix bugs on the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM dockerfile/java:openjdk-7-jdk
+FROM java:openjdk-7-jdk
 
 RUN apt-get update && apt-get install -y maven
 
@@ -8,5 +8,5 @@ WORKDIR /opt/kafka-websocket
 
 RUN mvn package
 
-CMD java -jar target/kafka-websocket-0.8.1-SNAPSHOT-shaded.jar
+CMD java -jar target/kafka-websocket-0.8.2-SNAPSHOT-shaded.jar
 


### PR DESCRIPTION
dockerfile/java:openjdk-7-jdk could not be pulled, replaced with java:openjdk-7-jdk
CMD was pointing at wrong version of the jar file
